### PR TITLE
New deployment handler loop

### DIFF
--- a/source/Minion_config.ini
+++ b/source/Minion_config.ini
@@ -13,7 +13,7 @@ ignore_wifi-hours = 0
 hours = 2
 camera_sample_rate = 10
 temppres_sample_rate = 5
-oxygen_sample_rate = 1
+oxygen_sample_period = 1
 
 [Time_Lapse_Samples]
 hours = 1

--- a/source/Recovery_Sampler_Burn.py
+++ b/source/Recovery_Sampler_Burn.py
@@ -18,6 +18,8 @@ MIN_DEPTH = 5  # Minimum Depth in dBar
 MIN_DEPTH_CNTR_THRESHOLD = 5  # Number of minimum pressure measurements before triggering a minimum depth condition
 ENABLE_MIN_DEPTH_CUTOUT = False  # Enables the Minimum Depth Cutout Feature
 ENABLE_MIN_DEPTH_CUTOUT_TEST = False  # TEST MODE ONLY!!!  DO NOT DEPLOY SET TO TRUE!!!
+_STROBE_ON = 100    # Strobe on time in milliseconds
+_STROBE_OFF = 4900  # Strobe off time in milliseconds
 
 # Initializations
 samp_num = 1
@@ -308,10 +310,17 @@ if __name__ == '__main__':
         write_pickle_file(fname_final_status_pickle, True)
         GPIO.output(pin_defs_dict['LED_GRN'], GPIO.LOW)  # Turn off the DATA ACQ LED Inidicator
 
+        # Transmit the first GPS Position and enable the strobe as soon as the sampling is complete
+        minion_hat.burn_wire(minion_hat.ENABLE)
+        minion_hat.strobe_timing(_STROBE_ON, _STROBE_OFF)
+        minion_hat.strobe(minion_hat.ENABLE)
+        os.system('sudo python /home/pi/Documents/Minion_scripts/xmt_minion_data.py &')
+
+
     else:
         print("Final Sampling Stage is complete.")
         minion_hat.burn_wire(minion_hat.ENABLE)
-        minion_hat.strobe_timing(100, 4900)  # On for 100ms / Off for 4900ms
+        minion_hat.strobe_timing(_STROBE_ON, _STROBE_OFF)
         minion_hat.strobe(minion_hat.ENABLE)
         os.system('sudo python /home/pi/Documents/Minion_scripts/xmt_minion_data.py &')
 

--- a/source/TempPres.py
+++ b/source/TempPres.py
@@ -111,7 +111,7 @@ while NumSamples < TotalSamples:
     tic = time.perf_counter()
 
     print("")
-    print("Time Lapse Sampling Mode")  # Indicate to the user in which mode the Minion is operating
+    print('Time Lapse Sampling Mode (' + str(samp_num) + ')')  # Indicate to the user in which mode the Minion is operating
 
     sensor_string = ''
 

--- a/source/minion_toolbox.py
+++ b/source/minion_toolbox.py
@@ -174,16 +174,16 @@ class MinionToolbox(object):
                 float INIsamp_hours : Number Sampling Hours (Initial Mode)
                 float INIsamp_camera_rate : Camera Sample Rate (Initial Mode)
                 float INIsamp_tempPres_rate : Temperature/Pressure Sample Rate (Initial Mode)
-                float INIsamp_oxygen_rate : Oxygen Sample Rate (Initial Mode)
+                float INIsamp_oxygen_period : Oxygen Sample Period in seconds (Initial Mode)
                 float FINsamp_hours : Number Sampling Hours (Final Mode)
                 float FINsamp_camera_rate : Camera Sample Rate (Finall Mode)
                 float FINsamp_tempPres_rate : Temperature/Pressure Sample Rate (Final Mode)
-                float FINsamp_oxygen_rate : Oxygen Sample Rate (Final Mode)
+                float FINsamp_oxygen_period : Oxygen Sample Period in seconds (Final Mode)
                 float TLPsamp_hours : Duration of Time Lapse Mode Sampling in hours
                 float TLPsamp_burst_minutes : Duration of a sample burst in Time-Lapse Mode
                 float TLPsamp_interval_minutes : Time between sample bursts in Time-Lapse Mode
                 float TLPsamp_tempPress_rate : Temperature / Pressure Sample Rate (Time-Lapse Mode)
-                float TLPsamp_oxygen_rate : Oxygen Sample Rate (Time-Lapse Mode)
+                float TLPsamp_oxygen_period : Oxygen Sample Period in seconds (Time-Lapse Mode)
                 float gps_transmission_window : Number of hours to transmit GPS positions before data transmission
                 float gps_transmission_interval : Number of minutes between GPS position transmissions
                 bool iniImg : Enable / Disable Image Capture
@@ -199,9 +199,9 @@ class MinionToolbox(object):
         # list of keys
         keys = ['Minion_ID', 'Abort', 'MAX_Depth', 'IG_WIFI_D', 'IG_WIFI_H',
                 'INIsamp_hours', 'INIsamp_camera_rate', 'INIsamp_tempPres_rate',
-                'INIsamp_oxygen_rate', 'FINsamp_hours', 'FINsamp_camera_rate',
-                'FINsamp_tempPres_rate', 'FINsamp_oxygen_rate', 'TLPsamp_tempPress_rate',
-                'TLPsamp_oxygen_rate', 'TLPsamp_hours', 'TLPsamp_burst_minutes', 'TLPsamp_interval_minutes',
+                'INIsamp_oxygen_period', 'FINsamp_hours', 'FINsamp_camera_rate',
+                'FINsamp_tempPres_rate', 'FINsamp_oxygen_period', 'TLPsamp_tempPress_rate',
+                'TLPsamp_oxygen_period', 'TLPsamp_hours', 'TLPsamp_burst_minutes', 'TLPsamp_interval_minutes',
                 'gps_transmission_window', 'gps_transmission_interval',
                 'iniImg', 'iniP30', 'iniP100', 'iniTmp', 'iniO2'
                 ]
@@ -225,12 +225,12 @@ class MinionToolbox(object):
         mission_config['INIsamp_hours'] = float(config['Initial_Samples']['hours'])
         mission_config['INIsamp_camera_rate'] = float(config['Initial_Samples']['camera_sample_rate'])
         mission_config['INIsamp_tempPres_rate'] = float(config['Initial_Samples']['temppres_sample_rate'])
-        mission_config['INIsamp_oxygen_rate'] = float(config['Initial_Samples']['oxygen_sample_rate'])
+        mission_config['INIsamp_oxygen_period'] = float(config['Initial_Samples']['oxygen_sample_period'])
 
         mission_config['FINsamp_hours'] = float(config['Final_Samples']['hours'])
         mission_config['FINsamp_camera_rate'] = float(config['Final_Samples']['camera_sample_rate'])
         mission_config['FINsamp_tempPres_rate'] = float(config['Final_Samples']['temppres_sample_rate'])
-        mission_config['FINsamp_oxygen_rate'] = float(config['Final_Samples']['oxygen_sample_rate'])
+        mission_config['FINsamp_oxygen_period'] = float(config['Final_Samples']['oxygen_sample_period'])
 
         mission_config['gps_transmission_window'] = float(config['GPS']['gps_transmission_window'])
         mission_config['gps_transmission_interval'] = float(config['GPS']['gps_transmission_interval'])
@@ -248,7 +248,7 @@ class MinionToolbox(object):
             # in the field such as 'Camera'
             mission_config['TLPsamp_burst_minutes'] = float(.2)
         mission_config['TLPsamp_tempPress_rate'] = float(config['Time_Lapse_Samples']['temppres_sample_rate'])
-        mission_config['TLPsamp_oxygen_rate'] = float(config['Time_Lapse_Samples']['oxygen_sample_rate'])
+        mission_config['TLPsamp_oxygen_period'] = float(config['Time_Lapse_Samples']['oxygen_sample_period'])
         mission_config['TLPsamp_interval_minutes'] = float(config['Time_Lapse_Samples']['sample_interval_minutes'])
 
         mission_config['iniImg'] = self.str2bool(config['Sampling_scripts']['image'])

--- a/source/web_iface/action_page.php
+++ b/source/web_iface/action_page.php
@@ -32,7 +32,7 @@ Oxybase O2 Sensor: <?php if ($_POST["OXY"]=="OXY"){echo "True";}else{echo "False
 Initial Sample Time (hours): <?php echo $_POST["IHours"]; ?><br>
 Camera Sample Rate (minutes): <?php echo $_POST["ICamFS"]; ?><br>
 Temperature and Pressure Sample Rate (Hz): <?php echo $_POST["ITPFS"]; ?><br>
-Dissolved Oxygen Sample Rate (Hz): <?php echo $_POST["IOXYFS"]; ?><br>
+Dissolved Oxygen Sample Period (seconds): <?php echo $_POST["IOXYFS"]; ?><br>
 </fieldset>
 
 <fieldset>
@@ -80,7 +80,7 @@ $Initial_Samples = "[Initial_Samples]\n"
   ."hours = ".$_POST["IHours"]."\n"
   ."camera_sample_rate = ".$_POST["ICamFS"]."\n"
   ."temppres_sample_rate = ".$_POST["ITPFS"]."\n"
-  ."oxygen_sample_rate = ".$_POST["IOXYFS"]."\n\n";
+  ."oxygen_sample_period = ".$_POST["IOXYFS"]."\n\n";
 
 fwrite($myfile, $Initial_Samples);
 
@@ -89,7 +89,7 @@ $Data_Sample = "[Time_Lapse_Samples]\n"
   ."sample_burst_duration = ".$_POST["DS_Time"]."\n"
   ."sample_interval_minutes = ".$_POST["DS_Interval"]."\n"
   ."temppres_sample_rate = ".$_POST["SensorFS"]."\n"
-  ."oxygen_sample_rate = ".$_POST["OxygenFS"]."\n\n";
+  ."oxygen_sample_period = ".$_POST["OxygenFS"]."\n\n";
 
 fwrite($myfile, $Data_Sample);
 
@@ -97,7 +97,7 @@ $Final_Samples = "[Final_Samples]\n"
   ."hours = ".$_POST["FHours"]."\n"
   ."camera_sample_rate = ".$_POST["FCamFS"]."\n"
   ."temppres_sample_rate = ".$_POST["FTPFS"]."\n"
-  ."oxygen_sample_rate = ".$_POST["FOXYFS"]."\n\n";
+  ."oxygen_sample_period = ".$_POST["FOXYFS"]."\n\n";
 
 fwrite($myfile, $Final_Samples);
 

--- a/source/web_iface/conf_edit.php
+++ b/source/web_iface/conf_edit.php
@@ -27,10 +27,12 @@ if ($cfg_file['Sampling_scripts']['temperature'] == 1) { $Temp = "checked";} els
 if ($cfg_file['Sampling_scripts']['oxybase'] == 1) { $OXY = "checked";} else { $OXY = "";}
 
 echo '<form action="/action_page.php" method="post">
-  <label for="DMAX">Maximum Depth (meters):</label>
-  <input type="text" id="DMAX" name="DMAX" value="'.$cfg_file['Mission']['max_depth'].'"><br><br>
+  <label for="DMAX">Maximum Depth:</label>
+  <br>
+  <input type="text" id="DMAX" name="DMAX" size="6" style="text-align:right" value="'.$cfg_file['Mission']['max_depth'].'"> meters<br>
+  <br>
   <fieldset>
-  <legend>Sensors</legend>
+  <legend><b>Sensors</b></legend>
   <input '.$Image.' type="checkbox" id="Image" name="Image" value="Image">
   <label for="Image"> Image</label><br>
   <input '.$BA30.' type="checkbox" id="30Bar_Pres" name="30Bar_Pres" value="30Bar_Pres">
@@ -42,61 +44,82 @@ echo '<form action="/action_page.php" method="post">
   <input '.$OXY.' type="checkbox" id="OXY" name="OXY" value="OXY">
   <label for="OXY"> Oxybase O2 Sensor</label><br>
   </fieldset>
-  <fieldset>
-  <legend>Initial Sampling Mode:</legend>
-  <label for="IHours">Initial Sample Time (hours):</label><br>
-  <input type="text" id="IHours" name="IHours" value="'.$cfg_file['Initial_Samples']['hours'].'"><br>
-  <label for="ICamFS">Camera Sample Rate (minutes):</label><br>
-  <input type="text" id="ICamFS" name="ICamFS" value="'.$cfg_file['Initial_Samples']['camera_sample_rate'].'"><br>
-  <label for="ITPFS">Temperature and Pressure Sample Rate (Hz):</label><br>
-  <input type="text" id="ITPFS" name="ITPFS" value="'.$cfg_file['Initial_Samples']['temppres_sample_rate'].'"><br>
-  <label for="IOXYFS">Dissolved Oxygen Sample Rate (Hz):</label><br>
-  <input type="text" id="IOXYFS" name="IOXYFS" value="'.$cfg_file['Initial_Samples']['oxygen_sample_rate'].'"><br>
-  </fieldset>
-  <fieldset>
-  <legend>Time Lapse Sampling Mode:</legend>
-  <label for="THours">Hours:</label><br>
-  <input type="text" id="THours" name="THours" value="'.$cfg_file['Time_Lapse_Samples']['hours'].'"><br>
-  <label for="DS_Time">Sample Burst Duration (min):</label><br>
-  <input type="text" id="DS_Time" name="DS_Time" value="'.$cfg_file['Time_Lapse_Samples']['sample_burst_duration'].'"><br>
-    <label for="DS_Interval">Sample Burst Interval (min):</label><br>
-  <input type="text" id="DS_Interval" name="DS_Interval" value="'.$cfg_file['Time_Lapse_Samples']['sample_interval_minutes'].'"><br>
-  <label for="SensorFS">Temperature and Pressure Sample Rate (Hz):</label><br>
-  <input type="text" id="SensorFS" name="SensorFS" value="'.$cfg_file['Time_Lapse_Samples']['temppres_sample_rate'].'"><br>
-  <label for="OxygenFS">Oxybase Sample Rate (Hz):</label><br>
-  <input type="text" id="OxygenFS" name="OxygenFS" value="'.$cfg_file['Time_Lapse_Samples']['oxygen_sample_rate'].'"><br>
-  </fieldset>
-  <fieldset>
-  <legend>Final Sampling Mode:</legend>
-  <label for="FHours">Final Sample Time (hours):</label><br>
-  <input type="text" id="FHours" name="FHours" value="'.$cfg_file['Final_Samples']['hours'].'"><br>
-  <label for="FCamFS">Camera Sample Rate (minutes):</label><br>
-  <input type="text" id="FCamFS" name="FCamFS" value="'.$cfg_file['Final_Samples']['camera_sample_rate'].'"><br>
-  <label for="FTPFS">Temperature and Pressure Sample Rate (Hz):</label><br>
-  <input type="text" id="FTPFS" name="FTPFS" value="'.$cfg_file['Final_Samples']['temppres_sample_rate'].'"><br>
-  <label for="FOXYFS">Dissolved Oxygen Sample Rate (Hz):</label><br>
-  <input type="text" id="FOXYFS" name="FOXYFS" value="'.$cfg_file['Final_Samples']['oxygen_sample_rate'].'"><br>
-  </fieldset>
-  <fieldset>
-  <legend>GPS Transmission Window Settings:</legend>
-  <label for="gps_dur_hrs">GPS Transmission Window Duration (hours):</label><br>
-  <input type="text" id="gps_dur_hrs" name="gps_dur_hrs" value="'.$cfg_file['GPS']['gps_transmission_window'].'"><br>
-  <label for="gps_interval_min">GPS Position Interval (minutes):</label><br>
-  <input type="text" id="gps_interval_min" name="gps_interval_min" value="'.$cfg_file['GPS']['gps_transmission_interval'].'"><br>
-  </fieldset>
-  <fieldset>
-  <legend>Ignore WIFI Signal:</legend>
   <br>
-  <label for="IG_WIFI-days">Days:</label>
-  <input type="text" id="IG_WIFI-days" name="IG_WIFI-days" value="'.$cfg_file['Mission']['ignore_wifi-days'].'"><br><br>
-  <label for="IG_WIFI-hours">Hours:</label>
-  <input type="text" id="IG_WIFI-hours" name="IG_WIFI-hours" value="'.$cfg_file['Mission']['ignore_wifi-hours'].'"><br>
-  </fieldset>
+  <fieldset>
+  <legend><b>Initial Sampling Mode</b></legend>
+  <br>
+  <label for="IHours">Total Mode Duration:</label><br>
+  <input type="text" id="IHours" name="IHours" size="6" style="text-align:right" value="'.$cfg_file['Initial_Samples']['hours'].'"> hours<br>
+  <br>
+  <label for="ICamFS">Image Capture Period:</label><br>
+  <input type="text" id="ICamFS" name="ICamFS" size="6" style="text-align:right" value="'.$cfg_file['Initial_Samples']['camera_sample_rate'].'"> minutes<br>
+  <br>
+  <label for="ITPFS">Temperature and Pressure Sample Rate:</label><br>
+  <input type="text" id="ITPFS" name="ITPFS" size="6" style="text-align:right" value="'.$cfg_file['Initial_Samples']['temppres_sample_rate'].'"> Hz<br>
+  <br>
+  <label for="IOXYFS">OxyBase Sample Period:</label><br>
+  <input type="text" id="IOXYFS" name="IOXYFS" size="6" style="text-align:right" value="'.$cfg_file['Initial_Samples']['oxygen_sample_period'].'"> seconds<br>
+  <br>
   </fieldset>
   <br>
   <fieldset>
-  <legend>Confirm Minion Number:</legend>
-  <input type="text" id="MNumber" name="MNumber" value="'.$cfg_file['MINION']['number'].'"  required/>
+  <legend><b>Time Lapse Sampling Mode</b></legend>
+  <p style="color:red;"><em>Note: If (Sample Burst Interval - Sample Burst Duration) < 2 minutes, the system will not enter low power mode between sample bursts.</em></p>
+  <label for="THours">Total Mode Duration:</label><br>
+  <input type="text" id="THours" name="THours" size="6" style="text-align:right" value="'.$cfg_file['Time_Lapse_Samples']['hours'].'"> hours<br>
+  <br>
+  <label for="DS_Time">Sample Burst Duration:</label><br>
+  <input type="text" id="DS_Time" name="DS_Time" size="6" style="text-align:right" value="'.$cfg_file['Time_Lapse_Samples']['sample_burst_duration'].'"> minutes<br>
+  <br>
+  <label for="DS_Interval">Sample Burst Interval:</label><br>
+  <input type="text" id="DS_Interval" name="DS_Interval" size="6" style="text-align:right" value="'.$cfg_file['Time_Lapse_Samples']['sample_interval_minutes'].'"> minutes<br>
+  <br>
+  <label for="SensorFS">Temperature and Pressure Sample Rate:</label><br>
+  <input type="text" id="SensorFS" name="SensorFS" size="6" style="text-align:right" value="'.$cfg_file['Time_Lapse_Samples']['temppres_sample_rate'].'"> Hz<br>
+  <br>
+  <label for="OxygenFS">OxyBase Sample Period:</label><br>
+  <input type="text" id="OxygenFS" name="OxygenFS" size="6" style="text-align:right" value="'.$cfg_file['Time_Lapse_Samples']['oxygen_sample_period'].'"> seconds<br>
+  <br>
+  </fieldset>
+  <br>
+  <fieldset>
+  <legend><b>Final Sampling Mode</b></legend>
+  <br>
+  <label for="FHours">Total Mode Duration:</label><br>
+  <input type="text" id="FHours" name="FHours" size="6" style="text-align:right" value="'.$cfg_file['Final_Samples']['hours'].'"> hours<br>
+  <br>
+  <label for="FCamFS">Image Capture Period:</label><br>
+  <input type="text" id="FCamFS" name="FCamFS" size="6" style="text-align:right" value="'.$cfg_file['Final_Samples']['camera_sample_rate'].'"> minutes<br>
+  <br>
+  <label for="FTPFS">Temperature and Pressure Sample Rate:</label><br>
+  <input type="text" id="FTPFS" name="FTPFS" size="6" style="text-align:right" value="'.$cfg_file['Final_Samples']['temppres_sample_rate'].'"> Hz<br>
+  <br>
+  <label for="FOXYFS">OxyBase Sample Period:</label><br>
+  <input type="text" id="FOXYFS" name="FOXYFS" size="6" style="text-align:right" value="'.$cfg_file['Final_Samples']['oxygen_sample_period'].'"> seconds<br>
+  <br>
+  </fieldset>
+  <br>
+  <fieldset>
+  <legend><b>GPS Transmission Window Settings</b></legend>
+  <br>
+  <label for="gps_dur_hrs">GPS Transmission Window Duration:</label><br>
+  <input type="text" id="gps_dur_hrs" name="gps_dur_hrs" size="6" style="text-align:right" value="'.$cfg_file['GPS']['gps_transmission_window'].'"> hours<br>
+  <br>
+  <label for="gps_interval_min">GPS Position Interval:</label><br>
+  <input type="text" id="gps_interval_min" name="gps_interval_min" size="6" style="text-align:right" value="'.$cfg_file['GPS']['gps_transmission_interval'].'"> minutes<br>
+  <br>
+  </fieldset>
+  <br>
+  <fieldset>
+  <legend><b>Ignore WIFI Signal</b></legend>
+  <br>
+  <input type="text" id="IG_WIFI-hours" name="IG_WIFI-hours" size="6" style="text-align:right" value="'.$cfg_file['Mission']['ignore_wifi-hours'].'"> hours<br>
+  <br>
+  </fieldset>
+  <br>
+  <fieldset>
+  <legend><b>Confirm Minion Number</b></legend>
+  <input type="text" id="MNumber" name="MNumber" size="6" style="text-align:right" value="'.$cfg_file['MINION']['number'].'"  required/>
   </fieldset>
   <br>
   <input type="submit" value="Review">

--- a/source/web_iface/new_mission.py
+++ b/source/web_iface/new_mission.py
@@ -4,6 +4,14 @@ import sys  # for sys.path
 sys.path.insert(0, '/home/pi/Documents/Minion_tools/')
 from minion_toolbox import MinionToolbox
 from minion_hat import MinionHat
+sys.path.insert(0, '/home/pi/Documents/Minion_scripts/')
+from minsat import MinSat
+
+# MinSat Board Settings
+gps_port = "/dev/ttySC0"
+gps_baud = 9600
+modem_port = "/dev/ttySC1"
+modem_baud = 19200
 
 # Sets the Final Sample Status Flag to False
 #    False : Final Samples Not Performed
@@ -22,6 +30,9 @@ minion_tools = MinionToolbox()
 # Create an instance of MinionHat()
 minion_hat = MinionHat()
 
+# Create an instance of MinSat()
+minion_sat = MinSat(gps_port, gps_baud, modem_port, modem_baud)
+
 # Delete the Data Transmit Status Pickle prior to mission start
 minion_tools.delete_data_xmt_status_pickle()
 
@@ -38,6 +49,14 @@ print('[OK] Disabled the Burn Wire')
 # Reset the Recovery Strobe
 minion_hat.strobe(minion_hat.DISABLE)
 print('[OK] Disabled the Recovery Strobe')
+
+# Power Down the GPS Module
+minion_sat.gps_pwr(minion_sat.dev_off)
+print('[OK] Powered Down the GPS Module')
+
+# Power Down the Iridium Modem
+minion_sat.modem_pwr(minion_sat.dev_off)
+print('[OK] Powered Down the Iridium Modem')
 
 time = os.popen('ls /home/pi/Desktop/minion_data/INI/1-*.txt').read()
 


### PR DESCRIPTION
Modified the Minion Deployment Handler to support a near rolling mode of burst sampling during time lapse mode.  If the difference between the burst sample interval and the burst sample duration is less than 2 minutes, the device will not enter the low power shutdown mode since it takes about a minute to start sampling after the RPi starts its boot process.  In addition, a first gps position is received and transmitted via iridium as soon as the final sampling is complete.  Modifications were made to support oxygen sample period instead of sample rate.  The PreSens OxyBase sensor requires slightly more than 1 second to complete and report a measurement so it did not make sense for this parameter to be in hertz.
[202310130902.pdf](https://github.com/ErranSousa/Minion_4/files/12893312/202310130902.pdf)
